### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,11 +10,11 @@ UCloud authentication for the awesome requests!
 .. image:: https://requires.io/github/SkyLothar/requests-ucloud/requirements.svg?branch=master
     :target: https://requires.io/github/SkyLothar/requests-ucloud/requirements/?branch=master
 
-.. image:: https://pypip.in/py_versions/requests-ucloud/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/pyversions/requests-ucloud.svg?style=flat
     :target: https://pypi.python.org/pypi/requests-ucloud/
     :alt: Supported Python versions
 
-.. image:: https://pypip.in/license/requests-ucloud/badge.svg?style=flat
+.. image:: https://img.shields.io/pypi/l/requests-ucloud.svg?style=flat
     :target: https://pypi.python.org/pypi/requests-ucloud/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20requests-ucloud))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `requests-ucloud`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.